### PR TITLE
Fix incorrect variable reference - $options -> $cp_options

### DIFF
--- a/includes/templates/collabpress/content-single-project-tasks.php
+++ b/includes/templates/collabpress/content-single-project-tasks.php
@@ -75,7 +75,7 @@
 					<th scope="row"><label for="cp-task-due"><?php _e('Notify via Email? ', 'collabpress') ?></label></th>
 					<?php
 					$cp_options = cp_get_options();
-					$checked = ( $options['email_notifications'] == 'enabled' ) ? 'checked="checked"' : null;
+					$checked = ( $cp_options['email_notifications'] == 'enabled' ) ? 'checked="checked"' : null;
 					?>
 					<td align="left"><p><input name="notify" id="notify" type="checkbox" <?php echo $checked; ?> /></p></td>
 				</tr>


### PR DESCRIPTION
Plugin options are loaded into a variable `$cp_options` in the line before an attempt is made to use them as `$options`. This corrects the use to be `$cp_options` instead and fixes the undefined variable notice.
