### PR TITLE
Update calendar template spelling mistake

### DIFF
--- a/includes/templates/collabpress/content-single-project-calendar.php
+++ b/includes/templates/collabpress/content-single-project-calendar.php
@@ -8,7 +8,7 @@
 
 	<div class="project-breadcrumb">
 		<h3 class="project-title"><?php cp_project_title(); ?></h3>
-		<h3>&nbsp;»&nbsp;<?php _e( 'Calendar', 'collabress' ); ?></h3>
+		<h3>&nbsp;»&nbsp;<?php _e( 'Calendar', 'collabpress' ); ?></h3>
 	</div>
 	<div class="calendar">
 		<?php


### PR DESCRIPTION
Changed 'collabress' on line 11 to 'collabpress'.
